### PR TITLE
fix: move operation silently swallowing error

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,41 @@
+version: "2"
+linters:
+  default: standard # errcheck,govet,ineffassign,staticcheck,unused
+  enable:
+    - nolintlint
+    - gocyclo
+    - nestif
+    - gosec
+    - dupl
+
+  # exclude test files
+  exclusions:
+    rules:
+      - path: '(.+)_test\.go'
+        linters:
+          - noop
+          - nestif
+          - dupl
+
+  settings:
+    nolintlint:
+      # Exclude following linters from requiring an explanation.
+      allow-no-explanation: []
+      # Enable to require an explanation of nonzero length after each nolint directive.
+      require-explanation: true
+      # Enable to require nolint directives to mention the specific linter being suppressed.
+      require-specific: true
+    gocyclo:
+      min-complexity: 20  # Default: 30 (but we recommend 10-20)
+    gocognit:
+      min-complexity: 20  # Default: 30 (but we recommend 10-20)
+    nestif:
+      min-complexity: 5   # Default: 5
+
+
+output:
+  sort-results: true
+  sort-order:
+    - file
+    - severity
+    - linter

--- a/closuretree.go
+++ b/closuretree.go
@@ -292,7 +292,10 @@ func (ct *Tree) Move(nodeId, newParentID uint, tenant string) error {
 		}
 		// make sure we don't delete items if nothing was moved, e.g. if we try to move cross Tenant unsuccessful
 		if exec1.RowsAffected == 0 {
-			return nil
+			// todo: this situation might be that the target parent does not exist or that it is trying to move
+			// the item to a different tenant, other errors might happen as well
+			// this error is not able to identify the differences between
+			return errors.New("node not moved to desired parent")
 		}
 
 		// Delete old closure relationships

--- a/closuretree_test.go
+++ b/closuretree_test.go
@@ -80,6 +80,7 @@ type NodeDetails struct {
 const tenant1 = "t1"
 const tenant2 = "t2"
 
+//nolint:gosec // int conversion is not critical here
 func getNodeDetails(item any) (bool, int, string) {
 
 	itemValue := reflect.ValueOf(item)
@@ -177,13 +178,13 @@ func TestAddNodes(t *testing.T) {
 					topItemDetails:   NodeDetails{Tenant: "T1"},
 					childItemDetails: NodeDetails{Tenant: "T2"},
 					topItemExpect:    NodeDetails{Id: 1, Tenant: "T1"},
-					childItemExpect:  NodeDetails{Err: closuretree.ParentNotFoundErr.Error()},
+					childItemExpect:  NodeDetails{Err: closuretree.ErrParentNotFoundErr.Error()},
 				},
 				{
 					name:            "Struct without ID field",
 					topItem:         &struct{ Name string }{Name: "NoID"},
-					topItemExpect:   NodeDetails{Err: closuretree.ItemIsNotTreeNode.Error()},
-					childItemExpect: NodeDetails{Err: closuretree.ItemIsNotTreeNode.Error()},
+					topItemExpect:   NodeDetails{Err: closuretree.ErrItemIsNotTreeNode.Error()},
+					childItemExpect: NodeDetails{Err: closuretree.ErrItemIsNotTreeNode.Error()},
 				},
 			}
 
@@ -335,7 +336,7 @@ func TestTreeGetNode(t *testing.T) {
 					in:          &map[string]string{},
 					wantPayload: TestPayload{},
 					tenant:      tenant1,
-					wantErr:     closuretree.ItemIsNotTreeNode.Error(),
+					wantErr:     closuretree.ErrItemIsNotTreeNode.Error(),
 				},
 				{
 					name:        "expect err because not passing pointer",
@@ -351,7 +352,7 @@ func TestTreeGetNode(t *testing.T) {
 					in:          &TestPayload{},
 					wantPayload: TestPayload{},
 					tenant:      tenant1,
-					wantErr:     closuretree.NodeNotFoundErr.Error(),
+					wantErr:     closuretree.ErrNodeNotFoundErr.Error(),
 				},
 			}
 			for _, tc := range tcs {
@@ -418,7 +419,7 @@ func TestUpdate(t *testing.T) {
 					in:          &map[string]string{},
 					wantPayload: TestPayload{},
 					tenant:      tenant1,
-					wantErr:     closuretree.ItemIsNotTreeNode.Error(),
+					wantErr:     closuretree.ErrItemIsNotTreeNode.Error(),
 				},
 				{
 					name:        "empty result on wrong Tenant",
@@ -426,7 +427,7 @@ func TestUpdate(t *testing.T) {
 					in:          TestPayload{Name: "Banana"},
 					wantPayload: TestPayload{},
 					tenant:      tenant1,
-					wantErr:     closuretree.NodeNotFoundErr.Error(),
+					wantErr:     closuretree.ErrNodeNotFoundErr.Error(),
 				},
 			}
 			for _, tc := range tcs {

--- a/example_test.go
+++ b/example_test.go
@@ -102,7 +102,7 @@ func ExampleTree_TreeDescendants() {
 	warmTag := Tag{Name: "warm", Node: ct.Node{}}
 	_ = tree.Add(&warmTag, colorTag.Id(), tenant)
 	_ = tree.Add(Tag{Name: "orange", Node: ct.Node{}}, warmTag.Id(), tenant)
-	// you can specify an unique ID for the branch
+	// you can specify a unique ID for the branch
 	_ = tree.Add(Tag{Name: "cold", Node: ct.Node{}}, colorTag.Id(), tenant)
 
 	sizes := Tag{Name: "sizes"}
@@ -128,7 +128,7 @@ func ExampleTree_TreeDescendants() {
 
 func printTree(nodes []*NestedTag, indent string) {
 	for _, n := range nodes {
-		fmt.Printf("%s%d=> %s\n", indent, n.Node.NodeId, n.Name)
+		fmt.Printf("%s%d=> %s\n", indent, n.NodeId, n.Name)
 		if len(n.Children) > 0 {
 			printTree(n.Children, "|- ")
 		}
@@ -146,7 +146,7 @@ type Genre struct {
 	Name    string
 }
 
-//nolint:govet
+//nolint:govet // example illustrates complex use-case
 func ExampleTreeWithM2MRelations() {
 
 	db := getGormDb("booksM2M.example")
@@ -260,7 +260,7 @@ type Song struct {
 	Genres []Genre `gorm:"many2many:songs_genres;"`
 }
 
-//nolint:govet
+//nolint:govet // example illustrates complex use-case
 func ExampleTreeWithLeaves() {
 
 	db := getGormDb("booksM2M.example")

--- a/leaves.go
+++ b/leaves.go
@@ -18,7 +18,7 @@ func (n *Leave) Id() uint {
 	return n.LeaveId
 }
 
-var ItemIsNotTreeLeave = errors.New("the item does not embed Leave")
+var ErrItemIsNotTreeLeave = errors.New("the item does not embed Leave")
 
 // isLeaveSlice uses reflection to verify if the passed item is a pointer to a slise that embedded Leave struct
 // returns an error for every condition checked, returns nil if the passed item is as expected
@@ -68,7 +68,7 @@ func isLeaveSlice(item any) error {
 	}
 
 	if !hasLeave {
-		return ItemIsNotTreeLeave
+		return ErrItemIsNotTreeLeave
 	}
 
 	if !hasManyToMany {


### PR DESCRIPTION
this PR fixes an issue where move operation was silently swallowing an error.
Other changes:
* new linter config
* code refactored to make linter happy
* make test coverage mandatory in make verify